### PR TITLE
require von calendar auskommentiert. falscher ort und an der stelle n…

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,6 @@
 load_theme_textdomain( 'fau', get_template_directory() . '/languages' );
 require_once( get_template_directory() . '/functions/defaults.php' );
 require_once( get_template_directory() . '/functions/constants.php' );
-require_once( get_template_directory() . '/functions/rrze-calendar-events-shortcode.php' );
 $options = fau_initoptions();
 require_once( get_template_directory() . '/functions/helper-functions.php' );
 require_once( get_template_directory() . '/functions/theme-options.php' );     

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ GitHub Theme URI: https://github.com/RRZE-Webteam/FAU-Einrichtungen
 Author: RRZE-Webteam
 Author URI: http://www.rrze.fau.de
 Description: Wordpress-Theme für zentrale Einrichtungen der Friedrich-Alexander-Universität Erlangen-Nürnberg (FAU)
-Version: 1.6.11
+Version: 1.6.12
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blue, gray, silver, white, three-columns, two-columns, one-column, right-sidebar, responsive-layout, featured-images, microformats


### PR DESCRIPTION
- CSS fuer Studienangebots-Plugin entfernt 
- fau-studiengangsplugin css und js raus 
- Bugfix #110
- widgets: categories und menu bei den listen neu gestaltet
- Vereinheitlichung Listenelemente in Sidebar und Widgets
- Bugfix: Weiterlesen-Link bei Artikel-teaser nun mit Screenreadertext 
- list items im portalmenu auf awesome umgestellt
- Externe Symbolgrafiken im portalmenu auf Awesome umgestellt
- Responsive Fix #109
- Performance Optimierung: list-arrow.png durch Awesome Icon ersetzt
- Codeverbesserung #107
- Logos fb wiso und fb jura drin #81
- Feintuning Anzeige von Personeninfos in der Sidebar
- Bugfix #118
- Bugfix #122: do_shortcode in text_widget
- Feintuning für neuen Kalender
- Add page_link shortcode attribute.
- FAU-Farben hinzugefügt
- Bugfix Personanzeige
- Darstellung RRZE Calendar verbessert 
