### PR TITLE
Update comments.php

### DIFF
--- a/functions/comments.php
+++ b/functions/comments.php
@@ -15,6 +15,7 @@ function fau_comment( $comment, $args, $depth ) {
         
         switch ( $comment->comment_type ) :
                 case '' :
+                case 'comment' :
         ?>
         <li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
           <div id="comment-<?php comment_ID(); ?>">


### PR DESCRIPTION
Seit Wordpress 5.5 wird bei Kommentartypen ein Default erzwungen. Siehe https://make.wordpress.org/core/2020/07/30/wordpress-5-5-field-guide/
Enforcing a default comment_type value

Dadurch wir beim Beitrag zwar angezeigt, das es Kommentare gibt; sie selbst werden aber nicht angezeigt.